### PR TITLE
Implemented Join methods on Worker & WorkerGroup

### DIFF
--- a/Moth.Tasks.Tests/Moth.Tasks.Tests.csproj
+++ b/Moth.Tasks.Tests/Moth.Tasks.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Moth.Tasks.Tests/WorkerGroupTests.cs
+++ b/Moth.Tasks.Tests/WorkerGroupTests.cs
@@ -13,7 +13,7 @@ namespace Moth.Tasks.Tests
         [Timeout (1000)]
         public void Work (int workerCount)
         {
-            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue ()))
+            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue (), true, true))
             {
                 EngageAllWorkers (workers);
             }
@@ -24,7 +24,7 @@ namespace Moth.Tasks.Tests
         {
             TaskQueue queue = new TaskQueue ();
 
-            using (WorkerGroup worker = new WorkerGroup (1, queue, disposeTaskQueue: true)) // Pass true for disposeTaskQueue
+            using (WorkerGroup worker = new WorkerGroup (1, queue, true, true)) // Pass true for disposeTaskQueue
             {
 
             }
@@ -38,7 +38,7 @@ namespace Moth.Tasks.Tests
         {
             int workerCount = 1;
 
-            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue ()))
+            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue (), true, true))
             {
                 Assert.AreEqual (workerCount, workers.WorkerCount);
             }
@@ -49,7 +49,7 @@ namespace Moth.Tasks.Tests
         {
             int workerCount = 1;
 
-            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue ()))
+            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue (), true, true))
             {
                 workerCount++;
                 workers.WorkerCount = workerCount;
@@ -66,7 +66,7 @@ namespace Moth.Tasks.Tests
         {
             int workerCount = 2;
 
-            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue ()))
+            using (WorkerGroup workers = new WorkerGroup (workerCount, new TaskQueue (), true, true))
             {
                 workerCount--;
                 workers.WorkerCount = workerCount;

--- a/Moth.Tasks/Moth.Tasks.csproj
+++ b/Moth.Tasks/Moth.Tasks.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Validation" Version="2.5.51" />
   </ItemGroup>
 

--- a/Moth.Tasks/Worker.cs
+++ b/Moth.Tasks/Worker.cs
@@ -107,6 +107,15 @@
         public TaskQueue Tasks => tasks;
 
         /// <summary>
+        /// Blocks the calling thread until the <see cref="Worker"/> terminates.
+        /// </summary>
+        public void DisposeAndJoin ()
+        {
+            Dispose ();
+            thread.Join ();
+        }
+
+        /// <summary>
         /// Sends a signal to shutdown the thread. Also disposes of <see cref="Tasks"/> if specified in <see cref="Worker"/> constructor.
         /// </summary>
         public void Dispose ()

--- a/Moth.Tasks/Worker.cs
+++ b/Moth.Tasks/Worker.cs
@@ -15,12 +15,11 @@
     /// </remarks>
     public class Worker : IDisposable
     {
-        private readonly TaskQueue tasks;
         private readonly bool disposeTasks;
-        private readonly Thread thread;
-        private readonly CancellationTokenSource cancelSource;
         private readonly IProfiler profiler;
         private readonly EventHandler<TaskExceptionEventArgs> exceptionEventHandler;
+        private readonly Thread thread;
+        private readonly CancellationTokenSource cancelSource = new CancellationTokenSource ();
         private int isRunningState;
 
         /// <summary>
@@ -66,13 +65,11 @@
             IProfiler profiler = null,
             EventHandler<TaskExceptionEventArgs> exceptionEventHandler = null)
         {
-            tasks = taskQueue ?? throw new ArgumentNullException (nameof (taskQueue), $"{nameof (taskQueue)} cannot be null.");
+            Tasks = taskQueue ?? throw new ArgumentNullException (nameof (taskQueue), $"{nameof (taskQueue)} cannot be null.");
             disposeTasks = disposeTaskQueue;
 
             if (disposeTasks)
-                GC.SuppressFinalize (tasks);
-
-            cancelSource = new CancellationTokenSource ();
+                GC.SuppressFinalize (Tasks);
 
             this.exceptionEventHandler = exceptionEventHandler;
             this.profiler = profiler;
@@ -102,16 +99,39 @@
         }
 
         /// <summary>
-        /// The <see cref="TaskQueue"/> of which the worker is executing tasks from.
+        /// Gets the <see cref="TaskQueue"/> of which the worker is executing tasks from.
         /// </summary>
-        public TaskQueue Tasks => tasks;
+        public TaskQueue Tasks { get; }
 
         /// <summary>
-        /// Blocks the calling thread until the <see cref="Worker"/> terminates.
+        /// Gets the <see cref="System.Threading.CancellationToken"/> associated with this worker.
+        /// </summary>
+        /// <remarks>
+        /// Can be passed to a task enqueued on <see cref="Tasks"/>, allowing it to exit early if <see cref="Dispose"/> is called.
+        /// </remarks>
+        public CancellationToken CancellationToken => cancelSource.Token;
+
+        /// <summary>
+        /// Calls <see cref="Dispose"/> and blocks the calling thread until the <see cref="Worker"/> terminates.
         /// </summary>
         public void DisposeAndJoin ()
         {
             Dispose ();
+            thread.Join ();
+        }
+
+        /// <summary>
+        /// Blocks the calling thread until the <see cref="Worker"/> terminates.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Dispose"/> must be called beforehand.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The <see cref="Worker>"/> is not disposed.</exception>
+        public void Join ()
+        {
+            if (!cancelSource.IsCancellationRequested)
+                throw new InvalidOperationException ("Join may only be called after the Worker is disposed.");
+
             thread.Join ();
         }
 
@@ -133,7 +153,7 @@
             cancelSource.Cancel ();
 
             if (disposeTasks)
-                tasks.Dispose ();
+                Tasks.Dispose ();
         }
 
         private void Work ()
@@ -146,7 +166,7 @@
 
                 while (!cancel.IsCancellationRequested)
                 {
-                    tasks.RunNextTask (out Exception exception, profiler, cancel);
+                    Tasks.RunNextTask (out Exception exception, profiler, cancel);
 
                     if (exception != null)
                     {


### PR DESCRIPTION
Adds a Join method, which calls Thread.Join on the internal thread(s) of Workers, after they have been disposed.

Also adds ad DisposeAndJoin method, which disposes of the worker, and waits for it to complete the current task.